### PR TITLE
to enable daemon on automated setups

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 clamav_packages:
   - clamav # for manual usage
-  # - clamav-daemon # for running clamav as daemon
+  - clamav-daemon # for running clamav as daemon
   # - clamav-freshclam # will installed anyway as dependency
 
 # Update virus signatures database each time role runs


### PR DESCRIPTION
While installing using the defaults I get an error as below- hence need to enable clamav-daemon also in defaults/main.yml
error from ansible using this role:
RUNNING HANDLER [clamav : restart clamav] **************************************
fatal: [test-mypost-dl-ftp]: FAILED! => {"changed": false, "failed": true, "msg": "no service or tool found for: clamav-daemo"}
