### PR TITLE
Syntax upgrade for Ansible 2.2 

### DIFF
--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -9,5 +9,5 @@
   apt:
     pkg: "{{ item }}"
     state: present
-  with_items: clamav_packages
+  with_items: "{{ clamav_packages }}"
   when: clamav_packages


### PR DESCRIPTION
Ansible 2.2 requires all variables to use the "{{ }}" notation.